### PR TITLE
Implement serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["ImJeremyHe<yiliang.he@qq.com>"]
 edition = "2018"
 name = "gents"
-version = "0.10.0"
+version = "1.0.0"
 license = "MIT"
 description = "generate Typescript interfaces from Rust code"
 repository = "https://github.com/ImJeremyHe/gents"
@@ -10,6 +10,7 @@ keywords = ["Typescript", "interface", "ts-rs", "Rust", "wasm"]
 
 [dependencies]
 dprint-plugin-typescript = "0.95.8"
+serde = { version = "1.0", features = ["derive"] }
 
 [workspace]
 members = ["./", "derives", "tests"]

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gents_derives"
-version = "0.10.0"
+version = "1.0.0"
 description = "provides some macros for gents"
 authors = ["ImJeremyHe<yiliang.he@qq.com>"]
 license = "MIT"

--- a/derives/src/serde_json.rs
+++ b/derives/src/serde_json.rs
@@ -1,0 +1,324 @@
+use crate::container::Container;
+use quote::{format_ident, quote};
+use syn::{parse::Parser, DeriveInput};
+
+pub fn get_serde_impl_block(
+    container: Container,
+    derive_input: &DeriveInput,
+) -> proc_macro2::TokenStream {
+    if container.is_enum {
+        get_serde_enum_impl_block(container, derive_input)
+    } else {
+        get_serde_struct_impl_block(container, derive_input)
+    }
+}
+
+fn get_serde_enum_impl_block(
+    container: Container,
+    _derive_input: &DeriveInput,
+) -> proc_macro2::TokenStream {
+    if !container.is_enum {
+        panic!("not support struct");
+    }
+    let generics = container.generics;
+    let mut unit_variants = Vec::new();
+    let mut non_unit_variants = Vec::new();
+    container.fields.into_iter().for_each(|f| {
+        if f.ty.is_none() {
+            unit_variants.push(f);
+        } else {
+            non_unit_variants.push(f);
+        }
+    });
+    let unit_ident = format_ident!("_GentsDummyUnitEnum{}", container.ident);
+    let unit_variant_dummy_enum = if !unit_variants.is_empty() {
+        let fields = unit_variants
+            .iter()
+            .map(|f| {
+                let ident = f.ident;
+                let rename = if f.rename.is_some() {
+                    let rename = f.rename.as_ref().unwrap();
+                    quote! {
+                        #[serde(rename = #rename)]
+                    }
+                } else {
+                    quote! {}
+                };
+                let skip = if f.skip {
+                    quote! {
+                        #[serde(skip)]
+                    }
+                } else {
+                    quote! {}
+                };
+                quote! {
+                    #rename
+                    #skip
+                    #ident,
+                }
+            })
+            .collect::<Vec<_>>();
+        quote! {
+            #[derive(::gents::serde::Serialize, ::gents::serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            #[serde(untagged)]
+            enum #unit_ident {
+                #(#fields)*
+            }
+        }
+    } else {
+        quote! {}
+    };
+    let non_unit_ident = format_ident!("_GentsDummyNonUnitEnum{}", container.ident);
+    let non_unit_variant_dummy_enum = if !non_unit_variants.is_empty() {
+        let fields = non_unit_variants
+            .iter()
+            .map(|f| {
+                let ident = f.ident;
+                let rename = if f.rename.is_some() {
+                    let rename = f.rename.as_ref().unwrap();
+                    quote! {
+                        #[serde(rename = #rename)]
+                    }
+                } else {
+                    quote! {}
+                };
+                let skip = if f.skip {
+                    quote! {
+                        #[serde(skip)]
+                    }
+                } else {
+                    quote! {}
+                };
+                let ty = f.ty.as_ref().unwrap();
+                quote! {
+                    #rename
+                    #skip
+                    #ident(#ty),
+                }
+            })
+            .collect::<Vec<_>>();
+        let tag = container.tag.expect("tag is required");
+        quote! {
+            #[derive(::gents::serde::Serialize, ::gents::serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            #[serde(tag = #tag, content="value")]
+            enum #non_unit_ident<#(#generics),*> {
+                #(#fields)*
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let dummy_ident = format_ident!("_GentsDummy{}", container.ident);
+    let dummy_unit_variant = if unit_variants.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            UnitDummy(#unit_ident),
+        }
+    };
+    let dummy_non_unit_variant = if non_unit_variants.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            TaggedDummy(#non_unit_ident<#(#generics),*>),
+        }
+    };
+    let dummy_enum = quote! {
+        #unit_variant_dummy_enum
+        #non_unit_variant_dummy_enum
+
+        #[derive(::gents::serde::Serialize, ::gents::serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(untagged)]
+        enum #dummy_ident<#(#generics),*> {
+            #dummy_unit_variant
+            #dummy_non_unit_variant
+        }
+
+    };
+    let generic_ser_bound = generics
+        .iter()
+        .map(|g| quote! { #g: ::serde::Serialize + ::gents::TS + Clone})
+        .collect::<Vec<_>>();
+    let generic_de_bound = generics
+        .iter()
+        .map(|g| quote! { #g: ::serde::Deserialize<'de> + ::gents::TS + Clone })
+        .collect::<Vec<_>>();
+    let ident = container.ident;
+    let serde_impl = {
+        let unit_ser = unit_variants
+            .iter()
+            .map(|v| {
+                let ident = v.ident;
+                quote! {Self::#ident => #dummy_ident::UnitDummy(#unit_ident::#ident),}
+            })
+            .collect::<Vec<_>>();
+        let tagged_ser = non_unit_variants
+            .iter()
+            .map(|v| {
+                let ident = v.ident;
+                quote! {
+                    Self::#ident(value) => {
+                        #dummy_ident::TaggedDummy(#non_unit_ident::#ident(value.clone()))
+                    },
+                }
+            })
+            .collect::<Vec<_>>();
+        let unit_de = unit_variants
+            .iter()
+            .map(|v| {
+                let ident = v.ident;
+                quote! {#dummy_ident::UnitDummy(#unit_ident::#ident) => Self::#ident,}
+            })
+            .collect::<Vec<_>>();
+        let tagged_de = non_unit_variants
+            .iter()
+            .map(|v| {
+                let ident = v.ident;
+                quote! {#dummy_ident::TaggedDummy(#non_unit_ident::#ident(value)) => Self::#ident(value),}
+            })
+            .collect::<Vec<_>>();
+        quote! {
+            impl<#(#generic_ser_bound),*> ::gents::serde::Serialize for #ident<#(#generics),*> {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where S: ::gents::serde::Serializer
+                {
+                    let dummy = match self {
+                        #(#unit_ser)*
+                        #(#tagged_ser)*
+                    };
+                    dummy.serialize(serializer)
+                }
+            }
+
+            impl<'de, #(#generic_de_bound),*> ::gents::serde::Deserialize<'de> for #ident<#(#generics),*> {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where D: ::gents::serde::Deserializer<'de>
+                {
+                    let dummy = #dummy_ident::deserialize(deserializer)?;
+                    Ok(match dummy {
+                        #(#unit_de)*
+                        #(#tagged_de)*
+                    })
+                }
+            }
+        }
+    };
+    quote! {
+        #dummy_enum
+        #serde_impl
+    }
+}
+
+// In this function, we will create a dummy struct/enum to implement serde traits.
+//
+// In this way, we can reuse the `serde` implementation of the struct/enum.
+fn get_serde_struct_impl_block(
+    container: Container,
+    derive_input: &DeriveInput,
+) -> proc_macro2::TokenStream {
+    if container.is_enum {
+        panic!("not support enum");
+    }
+    let mut dummy = derive_input.clone();
+    dummy.attrs.clear();
+    dummy.vis = syn::Visibility::Inherited;
+    dummy.ident = format_ident!("_GentsDummy{}", dummy.ident);
+    match &mut dummy.data {
+        syn::Data::Struct(d) => {
+            d.fields.iter_mut().enumerate().for_each(|(i, f)| {
+                f.attrs.clear();
+                if container.fields[i].skip {
+                    let attr = quote! {#[serde(skip)]};
+                    f.attrs
+                        .extend(syn::Attribute::parse_outer.parse2(attr).unwrap());
+                }
+                if container.fields[i].rename.is_some() {
+                    let rename = container.fields[i].rename.as_ref().unwrap();
+                    let attr = quote! {#[serde(rename = #rename)]};
+                    f.attrs
+                        .extend(syn::Attribute::parse_outer.parse2(attr).unwrap());
+                }
+            });
+        }
+        _ => panic!("not support"),
+    }
+
+    let generic_ser_bound = container
+        .generics
+        .iter()
+        .map(|g| quote! { #g: ::serde::Serialize + ::gents::TS + Clone})
+        .collect::<Vec<_>>();
+    let generic_de_bound = container
+        .generics
+        .iter()
+        .map(|g| quote! { #g: ::serde::Deserialize<'de> + ::gents::TS + Clone })
+        .collect::<Vec<_>>();
+    let generic_ts_bound = container
+        .generics
+        .iter()
+        .map(|g| quote! { #g: ::gents::TS })
+        .collect::<Vec<_>>();
+    let generic = container.generics;
+    let dummy_ident = &dummy.ident;
+    let ident = container.ident;
+
+    let from = {
+        let fields = container
+            .fields
+            .iter()
+            .map(|f| {
+                let ident = f.ident;
+                quote! {
+                    #ident: value.#ident,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        quote! {
+            impl<#(#generic_ts_bound),*> From<#dummy_ident<#(#generic),*>> for #ident<#(#generic),*> {
+                fn from(value: #dummy_ident<#(#generic),*>) -> Self {
+                    Self {
+                        #(#fields)*
+                    }
+                }
+            }
+        }
+    };
+
+    let dummy_type = quote! {
+        #[derive(::gents::serde::Serialize, ::gents::serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #dummy
+    };
+
+    let serde = {
+        quote! {
+            impl<#(#generic_ser_bound),*> ::gents::serde::Serialize for #ident<#(#generic),*> {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where S: ::gents::serde::Serializer
+                {
+                    let dummy: &#dummy_ident<#(#generic),*> = unsafe { std::mem::transmute(self) };
+                    #dummy_ident::serialize(dummy, serializer)
+                }
+            }
+
+            impl<'de, #(#generic_de_bound),*> ::gents::serde::Deserialize<'de> for #ident<#(#generic),*> {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where D: ::gents::serde::Deserializer<'de>
+                {
+                    let dummy = #dummy_ident::<#(#generic),*>::deserialize(deserializer)?;
+                    Ok(dummy.into())
+                }
+            }
+        }
+    };
+    quote! {
+        #dummy_type
+        #from
+        #serde
+    }
+}

--- a/derives/src/symbol.rs
+++ b/derives/src/symbol.rs
@@ -10,7 +10,6 @@ pub const RENAME: Symbol = Symbol("rename");
 pub const FILE_NAME: Symbol = Symbol("file_name");
 pub const SKIP: Symbol = Symbol("skip");
 pub const BUILDER: Symbol = Symbol("builder");
-pub const TAG_VALUE: Symbol = Symbol("tag_value");
 pub const TAG: Symbol = Symbol("tag");
 
 impl PartialEq<Symbol> for Ident {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,3 +60,5 @@ mod utils;
 
 pub use descriptor::*;
 pub use file_generator::*;
+
+pub use serde;

--- a/tests/src/serde_test/mod.rs
+++ b/tests/src/serde_test/mod.rs
@@ -1,6 +1,5 @@
 use gents::FileGroup;
 use gents_derives::TS;
-use serde::{Deserialize, Serialize};
 use std::{fs, process::Command};
 
 const TS_TESTS_DIR: &str = "src/serde_test/ts";
@@ -25,14 +24,14 @@ console.log('✅ JSON successfully matches the {file_name} TypeScript interface'
 console.log('Example:', typedData)
 "#;
 
-#[derive(Serialize, Deserialize, TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "user.ts")]
 pub struct User {
     pub id: u32,
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize, TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "test_enum.ts", rename_all = "camelCase", tag = "type")]
 pub enum TestEnum {
     Variant1(User),

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -1,13 +1,13 @@
 use gents_derives::TS;
 
-#[derive(TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "person.ts", rename_all = "camelCase")]
 pub struct Person {
     pub age: u16,
     pub en_name: String,
 }
 
-#[derive(TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "group.ts", rename_all = "camelCase")]
 pub struct Group {
     pub name: String,
@@ -16,7 +16,7 @@ pub struct Group {
     pub leader: Option<Person>,
 }
 
-#[derive(TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "gender.ts")]
 pub enum Gender {
     Male,
@@ -25,8 +25,9 @@ pub enum Gender {
     Unknown,
 }
 
-#[derive(TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "pet.ts", rename_all = "camelCase")]
+#[ts(tag = "type")]
 pub enum Pet {
     Cat(String),
     Dog(String),
@@ -34,7 +35,7 @@ pub enum Pet {
     None,
 }
 
-#[derive(TS)]
+#[derive(TS, Clone)]
 #[ts(file_name = "skip.ts", rename_all = "camelCase")]
 pub struct TestSkip {
     pub f1: u16,
@@ -48,7 +49,6 @@ mod tests {
 
     use super::*;
     use gents::*;
-    use gents_derives::gents_header;
 
     #[test]
     fn gen_skip_test() {
@@ -110,8 +110,8 @@ export interface Group {
         assert_eq!(
             content.trim(),
             r#"export type Gender =
-    | 'Male'
-    | 'Female'
+    | 'male'
+    | 'female'
     | 'null'"#
         );
     }
@@ -125,8 +125,8 @@ export interface Group {
         assert_eq!(
             content.trim(),
             r#"export type Pet =
-    | { cat: string }
-    | { dog: string }
+    | { type: 'cat'; value: string }
+    | { type: 'dog'; value: string }
     | 'None'"#
         );
     }
@@ -138,7 +138,7 @@ export interface Group {
         /**
         Block Comment
         */
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "struct_with_comments.ts", rename_all = "camelCase")]
         pub struct StructWithComments {
             /// field comment1
@@ -165,7 +165,7 @@ export interface StructWithComments {
 
     #[test]
     fn test_uint8array() {
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "file.ts", rename_all = "camelCase")]
         pub struct File {
             pub data: Vec<u8>,
@@ -186,7 +186,7 @@ export interface StructWithComments {
 
     #[test]
     fn test_builder() {
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "a.ts", rename_all = "camelCase")]
         #[ts(builder)]
         pub struct A {
@@ -210,7 +210,6 @@ export class ABuilder {
         this._f1 = value
         return this
     }
-
     public build() {
         if (this._f1 === undefined) throw new Error('missing f1')
         return { f1: this._f1 }
@@ -223,7 +222,7 @@ export class ABuilder {
 
     #[test]
     fn test_enum_tag_and_builder() {
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "a.ts", rename_all = "camelCase")]
         #[ts(builder)]
         pub struct Variant {
@@ -231,7 +230,7 @@ export class ABuilder {
             pub f2: String,
         }
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "a.ts", rename_all = "camelCase", tag = "type")]
         pub enum TaggedEnum {
             Variant(Variant),
@@ -244,13 +243,11 @@ export class ABuilder {
             content.trim(),
             r#"
 export interface Variant {
-    type: 'variant'
     f1: number
     f2: string
 }
 
 export class VariantBuilder {
-    private _type = 'variant'
     private _f1!: number
     private _f2!: string
     public f1(value: number) {
@@ -262,11 +259,10 @@ export class VariantBuilder {
         this._f2 = value
         return this
     }
-
     public build() {
         if (this._f1 === undefined) throw new Error('missing f1')
         if (this._f2 === undefined) throw new Error('missing f2')
-        return { type: this._type, f1: this._f1, f2: this._f2 }
+        return { f1: this._f1, f2: this._f2 }
     }
 }"#
             .trim()
@@ -275,21 +271,21 @@ export class VariantBuilder {
 
     #[test]
     fn test_enum_tag_and_builder_2() {
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(builder, file_name = "a.ts", rename_all = "camelCase")]
         pub struct V1 {
             pub f1: u8,
             pub f2: String,
         }
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "b.ts", rename_all = "camelCase")]
         #[ts(builder)]
         pub struct V2 {
             pub f3: u8,
         }
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "c.ts", rename_all = "camelCase", tag = "type")]
         pub enum TaggedEnum {
             #[ts(tag_value = "tag1")]
@@ -308,13 +304,11 @@ export class VariantBuilder {
                     c.trim(),
                     r#"
 export interface V1 {
-    type: 'tag1' | 'tag3'
     f1: number
     f2: string
 }
 
 export class V1Builder {
-    private _type!: 'tag1' | 'tag3'
     private _f1!: number
     private _f2!: string
     public f1(value: number) {
@@ -326,14 +320,10 @@ export class V1Builder {
         this._f2 = value
         return this
     }
-    public type(v: 'tag1' | 'tag3') {
-        this._type = v
-        return this
-    }
     public build() {
         if (this._f1 === undefined) throw new Error('missing f1')
         if (this._f2 === undefined) throw new Error('missing f2')
-        return { type: this._type, f1: this._f1, f2: this._f2 }
+        return { f1: this._f1, f2: this._f2 }
     }
 }"#
                     .trim()
@@ -344,21 +334,18 @@ export class V1Builder {
                     c.trim(),
                     r#"
 export interface V2 {
-    type: 'tag2'
     f3: number
 }
 
 export class V2Builder {
-    private _type = 'tag2'
     private _f3!: number
     public f3(value: number) {
         this._f3 = value
         return this
     }
-
     public build() {
         if (this._f3 === undefined) throw new Error('missing f3')
-        return { type: this._type, f3: this._f3 }
+        return { f3: this._f3 }
     }
 }"#
                     .trim()
@@ -372,9 +359,9 @@ import { V1 } from './a'
 import { V2 } from './b'
 
 export type TaggedEnum =
-    | V1
-    | V2
-    | V1"#
+    | { type: 'v1'; value: V1 }
+    | { type: 'v2'; value: V2 }
+    | { type: 'v3'; value: V1 }"#
                         .trim()
                 );
             }
@@ -383,9 +370,9 @@ export type TaggedEnum =
 
     #[test]
     fn test_generic() {
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "a.ts", rename_all = "camelCase")]
-        pub struct V1<T> {
+        pub struct V1<T: TS> {
             pub f1: T,
         }
 
@@ -399,9 +386,9 @@ export type TaggedEnum =
 }"#
         );
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "b.ts", rename_all = "camelCase")]
-        pub struct V2<T> {
+        pub struct V2<T: TS> {
             pub f1: V1<T>,
             pub f2: T,
         }
@@ -418,7 +405,7 @@ export interface V2<T> {
 }"#
         );
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "c.ts", rename_all = "camelCase")]
         pub struct V3 {
             pub f1: V2<String>,
@@ -438,7 +425,7 @@ export interface V3 {
 
     #[test]
     fn test_multiple_tags() {
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "a.ts", rename_all = "camelCase")]
         #[ts(builder)]
         pub struct V1 {
@@ -446,14 +433,14 @@ export interface V3 {
             pub f2: String,
         }
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "b.ts", rename_all = "camelCase")]
         #[ts(builder)]
         pub struct V2 {
             pub f3: u8,
         }
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "a.ts", tag = "type")]
         pub enum A {
             V1(V1),
@@ -461,7 +448,7 @@ export interface V3 {
             V3(V1),
         }
 
-        #[derive(TS)]
+        #[derive(TS, Clone)]
         #[ts(file_name = "b.ts", tag = "type2")]
         pub enum B {
             V1(V1),
@@ -474,33 +461,5 @@ export interface V3 {
         B::_register(&mut manager, true);
         let data = manager.gen_data();
         assert_eq!(data.len(), 4);
-    }
-
-    #[test]
-    fn test_result() {
-        #[gents_header(file_name = "test_struct.ts")]
-        pub struct TestStruct {
-            pub f1: u8,
-            pub f2: Result<String, u16>,
-        }
-        let mut manager = DescriptorManager::default();
-        TestStruct::_register(&mut manager, true);
-        let (_, content) = manager.gen_data().into_iter().next().unwrap();
-        assert_eq!(
-            content.trim(),
-            r#"export interface TestStruct {
-    f1: number
-    f2: string | number
-}"#
-        );
-    }
-
-    #[test]
-    fn test_gents_for_wasm() {
-        #[gents_header(file_name = "test_struct.ts")]
-        pub struct TestStruct {
-            pub f1: u8,
-            pub f2: String,
-        }
     }
 }


### PR DESCRIPTION
### Breaking changes
We adopted a new way of generating `Enum`s' Typescript for better `serde` support.

Given an enum:
```rust
#[derive(TS, Clone)]
#[ts(file_name = "pet.ts", rename_all = "camelCase")]
#[ts(tag = "type")]
pub enum Pet {
    Cat(String),
    Dog(String),
    None,
}
```

We will generate Typescript interfaces:
```ts
export type Pet =
    | { type: 'cat'; value: string }
    | { type: 'dog'; value: string }
    | 'none'
```

Unit variants don't have `tag`s and unamed variants always have a tag.

`gents_header` is also removed, as `TS` has automatically implemented `serde::Serialize` and `serde::Deserialize`