### PR TITLE
Skip serializing if Option::is_none

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["ImJeremyHe<yiliang.he@qq.com>"]
 edition = "2018"
 name = "gents"
-version = "1.0.3"
+version = "1.0.4"
 license = "MIT"
 description = "generate Typescript interfaces from Rust code"
 repository = "https://github.com/ImJeremyHe/gents"
@@ -11,6 +11,7 @@ keywords = ["Typescript", "interface", "ts-rs", "Rust", "wasm"]
 [dependencies]
 dprint-plugin-typescript = "0.95.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "3.14.0"
 
 [workspace]
 members = ["./", "derives", "tests"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 It bridges the gap between Rust backends and TypeScript frontends by automatically generating type definitions, making it easy to use `serde-json` for communication between the two languages without manually maintaining duplicate type stubs.
 
 **Why use gents?**
+****
 
 - **Automatic type synchronization:** When your Rust data models change, you can instantly regenerate matching TypeScript interfaces, ensuring your frontend and backend always stay in sync.
 - **Eliminate manual boilerplate:** No need to hand-write or update TypeScript types every time your Rust structs or enums change, reducing human error and saving time.
@@ -23,7 +24,7 @@ This tool is designed for [LogiSheets](https://github.com/proclml/LogiSheets) an
 
 Your issues and PRs are welcome!
 
----
+****
 
 ## 🛠️ How to Use `gents` (Quickstart & Advanced)
 
@@ -65,7 +66,7 @@ You can use `rename_all` and `rename` for field naming policies.
 
 ### 3. Generate TypeScript Files
 
-Write a unit test (or integration test):
+Write a binary or unit test:
 
 ```rust
 #[ignore]
@@ -80,6 +81,8 @@ fn gents() {
 }
 ```
 
+Since `Group` has dependencies on `Person`, `gents` will automatically include `Person` in the generated files.
+
 - Run with `cargo test -- --ignored` to generate files.
 
 ### 4. Output Directory
@@ -87,17 +90,12 @@ fn gents() {
 - All generated `.ts` files will be placed in the directory you specify (e.g., `outdir`).
 - If you set the second argument of `gen_files` to `true`, an `index.ts` exporting all types will be generated.
 
-### 5. Cross-Crate Usage
-
-If your `TS` derives are spread across multiple crates, define a feature called `gents` in each crate and use `#[cfg(feature = "gents")]` to control code generation.
-See [LogiSheets example](https://github.com/proclml/LogiSheets/blob/master/crates/buildtools/src/generate.rs) for advanced multi-crate setup.
-
-### 6. Integration with Frontend
+### 5. Integration with Frontend
 
 - Add the generated `.ts` files to your frontend project (or link via a monorepo).
 - Now your TypeScript code can safely import and use the types generated from Rust, ensuring type consistency.
 
----
+****
 
 ## 💡 Advanced Tips
 
@@ -108,7 +106,7 @@ See [LogiSheets example](https://github.com/proclml/LogiSheets/blob/master/crate
 - **Use in CI:**
   You can run the generation test in your CI pipeline to ensure TypeScript types are always up to date.
 
----
+****
 
 ## Why not  `ts-rs`?
 

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gents_derives"
-version = "1.0.3"
+version = "1.0.4"
 description = "provides some macros for gents"
 authors = ["ImJeremyHe<yiliang.he@qq.com>"]
 license = "MIT"

--- a/derives/src/serde_json.rs
+++ b/derives/src/serde_json.rs
@@ -312,6 +312,7 @@ fn get_serde_struct_impl_block(
     };
 
     let dummy_type = quote! {
+        #[::gents::serde_with::skip_serializing_none]
         #[derive(::gents::serde::Serialize, ::gents::serde::Deserialize)]
         #rename_all
         #dummy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,4 @@ pub use descriptor::*;
 pub use file_generator::*;
 
 pub use serde;
+pub use serde_with;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -85,3 +85,33 @@ fn test_struct_tagged_enum_serde() {
         _ => panic!(),
     }
 }
+
+#[derive(Debug, Clone, gents_derives::TS)]
+#[ts(file_name = "b.ts", rename_all = "camelCase")]
+pub struct Pet {
+    pub name: String,
+    pub owner: Option<User>,
+}
+
+#[test]
+fn test_option_none_to_json() {
+    let pet = Pet {
+        name: "test".to_string(),
+        owner: None,
+    };
+    let json = serde_json::to_string(&pet).unwrap();
+    assert_eq!(json, "{\"name\":\"test\"}");
+
+    let pet = Pet {
+        name: "test".to_string(),
+        owner: Some(User {
+            id: 1,
+            name: "test".to_string(),
+        }),
+    };
+    let json = serde_json::to_string(&pet).unwrap();
+    assert_eq!(
+        json,
+        "{\"name\":\"test\",\"owner\":{\"id\":1,\"name\":\"test\"}}"
+    );
+}

--- a/tests/src/serde_test/mod.rs
+++ b/tests/src/serde_test/mod.rs
@@ -36,6 +36,7 @@ pub struct User {
 pub enum TestEnum {
     Variant1(User),
     Variant2(User),
+    Variant3,
 }
 
 #[test]
@@ -74,6 +75,24 @@ fn test_ts_rust_json_compatibility_enum() {
         TestEnum::Variant1(_) => assert!(true),
         _ => assert!(false),
     }
+
+    let test_enum = TestEnum::Variant3;
+    let json = serde_json::to_string(&test_enum).unwrap();
+    fs::write(format!("{}/{}.json", JS_DIR, file_name), &json).unwrap();
+
+    let ts_file_content = CHECK_PATTERN
+        .replace("{file_name}", file_name)
+        .replace("{type_name}", type_name);
+    fs::write("src/serde_test/ts/check.ts", ts_file_content).unwrap();
+
+    let path = fs::canonicalize("src/serde_test/ts").unwrap();
+
+    let status = Command::new("npm")
+        .args(["run", "check"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success(), "TypeScript failed to check types");
 }
 
 #[test]


### PR DESCRIPTION
This will minimize the JSON object size and be consistent with generated Typescript interfaces